### PR TITLE
Use SPIFFS to allow easy access to HTML/CSS while still being easily available on the ESP32 flash

### DIFF
--- a/src/envmon/data/index.html
+++ b/src/envmon/data/index.html
@@ -1,7 +1,11 @@
 <!DOCTYPE html>
 <html>
-<title>ESP32 Environment Monitor</title>
-<link rel="stylesheet" type="text/css" href="style.css">
+<head>
+    <meta charset="UTF-8" />
+    <title>ESP32 Environment Monitor</title>
+    <link rel="stylesheet" type="text/css" href="style.css">
+    <link rel="shortcut icon" type="image/png" href="https://github.com/furquan-lp/environment-monitor/raw/master/icon.png">
+</head>
 <body>
     <div class="esp32data">
         <h1>ESP32 Environment Monitor v1.2</h1>
@@ -14,6 +18,5 @@
         window.location.reload(1);
     }, 3000);
     </script>
-    <br>
 </body>
 </html>

--- a/src/envmon/data/index.html
+++ b/src/envmon/data/index.html
@@ -1,22 +1,14 @@
 <!DOCTYPE html>
 <html>
 <title>ESP32 Environment Monitor</title>
-<style type="text/css">
-    body {
-        font-family: Sans-Serif;
-        color:#444;
-    }
-    .esp32data {
-        background-color: #FFFFCC
-    }
-</style>
+<link rel="stylesheet" type="text/css" href="style.css">
 <body>
     <div class="esp32data">
-        <h1>ESP32 Environment Monitor v0.x</h1>
+        <h1>ESP32 Environment Monitor v1.2</h1>
         <h2>Temperature: %.2f&deg;C Humidity: %.2f&#37;</h2>
         <h4>Up since %02d:%02d:%02d</h4>
     </div>
-    <p style="font-family:serif">Last updated: 2021-10-27 Copyright (C) 2021 Syed Furquan Ahmad</p>
+    <p style="font-family:serif">Last updated: 2021-11-02 Copyright (C) 2021 Syed Furquan Ahmad</p>
     <script>
     setTimeout(function(){
         window.location.reload(1);

--- a/src/envmon/data/style.css
+++ b/src/envmon/data/style.css
@@ -1,3 +1,7 @@
 body {
     font-family: Sans-Serif;
+    color:#444;
+}
+.esp32data {
+    background-color: #FFFFCC
 }

--- a/src/envmon/data/style.css
+++ b/src/envmon/data/style.css
@@ -3,5 +3,5 @@ body {
     color:#444;
 }
 .esp32data {
-    background-color: #FFFFCC
+    background-color: #FFFFCC;
 }

--- a/src/envmon/envmon.h
+++ b/src/envmon/envmon.h
@@ -8,34 +8,12 @@
 const char* ssid = "****";
 const char* password = "****";
 const char* mdns_url = "esp32env";
-const char* html_data = "<!DOCTYPE html>\
-<html>\
-<title>ESP32 Environment Monitor</title>\
-<style type=\"text/css\">\
-body{\
-font-family: Sans-Serif;color:#444;\
-}\
-.esp32data {\
-background-color: #FFFFCC\
-}\
-</style>\
-<body>\
-<div class=\"esp32data\">\
-<h1>ESP32 Environment Monitor v1.1</h1>\
-<h2>Temperature: %.2f&deg;C Humidity: %.2f&#37;</h2>\
-<h4>Up since %02d:%02d:%02d</h4></div>\
-<p style=\"font-family:serif\">Last updated: 2021-11-02 Copyright (C) 2021 Syed Furquan Ahmad</p>\
-<script>\
-setTimeout(function(){\
-window.location.reload(1);\
-}, 3000);\
-</script>\
-<br>\
-</body>\
-</html>";
+char html_data[1000];
+char css_data[500];
 
 WebServer server(HTTP_PORT);
 CharacterLCD clcd(0x27, 16, 2);
 
+void read_html_css(void);
 void handle_root(void);
 #endif

--- a/src/envmon/envmon.h
+++ b/src/envmon/envmon.h
@@ -15,5 +15,6 @@ WebServer server(HTTP_PORT);
 CharacterLCD clcd(0x27, 16, 2);
 
 void read_html_css(void);
+void show_err_lcd(const char* line1, const char* line2);
 void handle_root(void);
 #endif

--- a/src/envmon/envmon.ino
+++ b/src/envmon/envmon.ino
@@ -16,8 +16,6 @@ void setup() {
         Serial.println("An Error has occurred while mounting SPIFFS");
         return;
     }
-    clcd.printLCD("Reading HTML/CSS");
-    delay(100);
     read_html_css();
 
     Serial.println("Connecting to ");
@@ -26,10 +24,18 @@ void setup() {
     clcd.printLCD("Connecting WiFi");
     WiFi.begin(ssid, password);
     clcd.selectLine(1);
+    uint8_t n = 0;
     while (WiFi.status() != WL_CONNECTED) {
+        if (n >= 10) {
+            show_err_lcd("WiFi failed.", "Rebooting...");
+            delay(1000);
+            ESP.restart();
+            return;
+        }
         delay(1000);
         Serial.print(".");
         clcd.printLCD(".");
+        n++;
     }
     clcd.clearLCD();
     Serial.println("\nWiFi connected");

--- a/src/envmon/envmon.ino
+++ b/src/envmon/envmon.ino
@@ -72,8 +72,8 @@ void loop() {
 }
 
 void read_html_css() {
-    File html = SPIFFS.open("/index.html");
-    File css = SPIFFS.open("/style.css");
+    File html = SPIFFS.open("/index.html", "r");
+    File css = SPIFFS.open("/style.css", "r");
     if (!html) {
         show_err_lcd("index.html fail", "Stop.");
         Serial.println("Failed to open index.html");

--- a/src/envmon/envmon.ino
+++ b/src/envmon/envmon.ino
@@ -12,14 +12,13 @@ void setup() {
     Serial.begin(115200);
 
     if(!SPIFFS.begin(true)){
-        clcd.printLCD("Filesystem Error");
-        clcd.printAt("Stop.", 1);
+        show_err_lcd("Filesystem Error", "Stop.");
         Serial.println("An Error has occurred while mounting SPIFFS");
         return;
     }
     clcd.printLCD("Reading HTML/CSS");
     delay(100);
-    readHTMLCSS();
+    read_html_css();
 
     Serial.println("Connecting to ");
     Serial.println(ssid);
@@ -66,13 +65,11 @@ void loop() {
     server.handleClient();
 }
 
-void readHTMLCSS() {
+void read_html_css() {
     File html = SPIFFS.open("/index.html");
     File css = SPIFFS.open("/style.css");
     if (!html) {
-        clcd.clearLCD();
-        clcd.printLCD("index.html fail");
-        clcd.printAt("Stop.", 1);
+        show_err_lcd("index.html fail", "Stop.");
         Serial.println("Failed to open index.html");
         return;
     }
@@ -84,6 +81,12 @@ void readHTMLCSS() {
     }
     html.close();
     css.close();
+}
+
+void show_err_lcd(const char* line1, const char* line2) {
+    clcd.clearLCD();
+    clcd.printLCD(line1);
+    clcd.printAt(line2, 1);
 }
 
 void handle_root() {


### PR DESCRIPTION
New features:
* SPIFFS filesystem allows the separation of the HTML/CSS data in `data/index.html` and `data/style.css` for easy access
* Using SPIFFS avoids hardcoding of the HTML/CSS data and all the bugs associated with that
* Reset the ESP32 board upon failure to connect to WiFi